### PR TITLE
Improve local Android CI script checks and add APK upload to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,9 @@ jobs:
 
       - name: Assemble debug
         run: gradle :app:assembleDebug
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-apk
+          path: app/build/outputs/apk/debug/app-debug.apk

--- a/app-android/scripts/run-ci-local.sh
+++ b/app-android/scripts/run-ci-local.sh
@@ -2,16 +2,28 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER_JAR="$ROOT_DIR/gradle/wrapper/gradle-wrapper.jar"
+GRADLE_CMD=""
 
-if ! command -v gradle >/dev/null 2>&1; then
+if [[ -f "$ROOT_DIR/gradlew" && -f "$WRAPPER_JAR" ]]; then
+  GRADLE_CMD=(bash "$ROOT_DIR/gradlew")
+elif command -v gradle >/dev/null 2>&1; then
+  GRADLE_CMD=(gradle)
+else
   echo "Gradle is required to run CI locally."
-  echo "Install Gradle 9.1.0 or ensure it is on your PATH."
+  echo "Install Gradle 9.1.0 or add the wrapper jar at $WRAPPER_JAR."
   exit 1
 fi
 
 echo "==> Running Android CI steps locally"
 cd "$ROOT_DIR"
 
-gradle :app:lint
-gradle :app:test
-gradle :app:assembleDebug
+if [[ -z "${ANDROID_HOME:-}" && -z "${ANDROID_SDK_ROOT:-}" ]]; then
+  echo "ANDROID_HOME/ANDROID_SDK_ROOT is not set."
+  echo "Set ANDROID_HOME (or ANDROID_SDK_ROOT) to your Android SDK path."
+  exit 1
+fi
+
+"${GRADLE_CMD[@]}" :app:lint
+"${GRADLE_CMD[@]}" :app:test
+"${GRADLE_CMD[@]}" :app:assembleDebug


### PR DESCRIPTION
### Motivation
- Prevent opaque local CI failures by making the local Android CI script more robust and by validating Android SDK presence before running Gradle tasks.
- Ensure the built debug APK is published as a CI artifact so it can be downloaded from workflow runs.

### Description
- Add an `Upload debug APK` step to `.github/workflows/ci.yml` using `actions/upload-artifact@v4` to publish `app/build/outputs/apk/debug/app-debug.apk`.
- Replace strict `gradle`-only checks in `app-android/scripts/run-ci-local.sh` with logic that prefers the Gradle wrapper when present and falls back to system `gradle` when available.
- Detect the wrapper jar at `gradle/wrapper/gradle-wrapper.jar` and invoke the wrapper via `bash ./gradlew` when appropriate, otherwise use `gradle` from PATH.
- Add an environment check that requires `ANDROID_HOME` or `ANDROID_SDK_ROOT` to be set before running `:app:lint`, `:app:test`, and `:app:assembleDebug` to surface missing SDK configuration early.

### Testing
- Ran `./scripts/run-ci-local.sh` in the `app-android` directory and the script exited non-zero because `ANDROID_HOME/ANDROID_SDK_ROOT` was not set, which demonstrates the new early SDK check is effective (expected failure in this environment).
- Earlier runs (before adding the SDK check) produced a Gradle failure (`25.0.1`), showing the prior behavior produced opaque build errors that the updated checks now avoid.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976d299037c832197891063a7c9cb0f)