### PR TITLE
Add seeded home list UI and Room relations

### DIFF
--- a/app-android/app/src/main/java/com/compareprices/data/local/Daos.kt
+++ b/app-android/app/src/main/java/com/compareprices/data/local/Daos.kt
@@ -4,6 +4,8 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface ProductDao {
@@ -12,6 +14,9 @@ interface ProductDao {
 
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun upsertAll(items: List<ProductEntity>)
+
+  @Insert(onConflict = OnConflictStrategy.REPLACE)
+  suspend fun insertAll(items: List<ProductEntity>): List<Long>
 }
 
 @Dao
@@ -39,6 +44,13 @@ interface ShoppingListDao {
 
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun upsert(item: ShoppingListEntity): Long
+
+  @Query("SELECT COUNT(*) FROM shopping_lists")
+  suspend fun count(): Int
+
+  @Transaction
+  @Query("SELECT * FROM shopping_lists ORDER BY createdAt DESC LIMIT 1")
+  fun observeLatestList(): Flow<ShoppingListWithItems?>
 }
 
 @Dao

--- a/app-android/app/src/main/java/com/compareprices/data/local/Entities.kt
+++ b/app-android/app/src/main/java/com/compareprices/data/local/Entities.kt
@@ -1,8 +1,10 @@
 package com.compareprices.data.local
 
+import androidx.room.Embedded
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import androidx.room.Relation
 
 @Entity(tableName = "products")
 data class ProductEntity(
@@ -52,4 +54,20 @@ data class ListItemEntity(
   val productId: Long,
   val quantity: Double,
   val unit: String
+)
+
+data class ListItemWithProduct(
+  @Embedded val item: ListItemEntity,
+  @Relation(parentColumn = "productId", entityColumn = "id")
+  val product: ProductEntity
+)
+
+data class ShoppingListWithItems(
+  @Embedded val list: ShoppingListEntity,
+  @Relation(
+    entity = ListItemEntity::class,
+    parentColumn = "id",
+    entityColumn = "listId"
+  )
+  val items: List<ListItemWithProduct>
 )

--- a/app-android/app/src/main/java/com/compareprices/ui/AppRoot.kt
+++ b/app-android/app/src/main/java/com/compareprices/ui/AppRoot.kt
@@ -1,6 +1,5 @@
 package com.compareprices.ui
 
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -14,13 +13,13 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.compareprices.ui.home.HomeScreen
 
 private sealed class Screen(val route: String, val label: String) {
   data object Home : Screen("home", "Lista")
@@ -77,11 +76,6 @@ fun AppRoot() {
 }
 
 @Composable
-private fun HomeScreen() {
-  PlaceholderScreen(label = "Home - Lista de compras")
-}
-
-@Composable
 private fun CompareScreen() {
   PlaceholderScreen(label = "Comparador por tienda")
 }
@@ -93,7 +87,10 @@ private fun SettingsScreen() {
 
 @Composable
 private fun PlaceholderScreen(label: String) {
-  Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+  androidx.compose.foundation.layout.Box(
+    modifier = Modifier.fillMaxSize(),
+    contentAlignment = androidx.compose.ui.Alignment.Center
+  ) {
     Text(text = label)
   }
 }

--- a/app-android/app/src/main/java/com/compareprices/ui/home/HomeScreen.kt
+++ b/app-android/app/src/main/java/com/compareprices/ui/home/HomeScreen.kt
@@ -1,0 +1,116 @@
+package com.compareprices.ui.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.compareprices.data.local.ListItemWithProduct
+
+@Composable
+fun HomeScreen(viewModel: HomeViewModel = hiltViewModel()) {
+  val uiState by viewModel.uiState.collectAsState()
+  val list = uiState.list
+
+  if (list == null) {
+    EmptyHomeState()
+    return
+  }
+
+  LazyColumn(
+    modifier = Modifier.fillMaxSize(),
+    contentPadding = PaddingValues(16.dp),
+    verticalArrangement = Arrangement.spacedBy(12.dp)
+  ) {
+    item {
+      Card(
+        colors = CardDefaults.cardColors(
+          containerColor = MaterialTheme.colorScheme.surfaceVariant
+        ),
+        modifier = Modifier.fillMaxWidth()
+      ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+          Text(text = list.list.name, style = MaterialTheme.typography.titleLarge)
+          Spacer(modifier = Modifier.height(4.dp))
+          Text(
+            text = "${list.items.size} productos en tu lista",
+            style = MaterialTheme.typography.bodyMedium
+          )
+        }
+      }
+    }
+
+    items(list.items) { listItem ->
+      ListItemCard(listItem)
+    }
+  }
+}
+
+@Composable
+private fun EmptyHomeState() {
+  Column(
+    modifier = Modifier
+      .fillMaxSize()
+      .padding(24.dp),
+    verticalArrangement = Arrangement.Center,
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
+    Text(
+      text = "Tu lista esta vacia",
+      style = MaterialTheme.typography.titleMedium,
+      fontWeight = FontWeight.SemiBold
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Text(
+      text = "Agrega productos para comparar precios entre tiendas.",
+      style = MaterialTheme.typography.bodyMedium
+    )
+  }
+}
+
+@Composable
+private fun ListItemCard(listItem: ListItemWithProduct) {
+  Card(modifier = Modifier.fillMaxWidth()) {
+    Column(modifier = Modifier.padding(16.dp)) {
+      Text(
+        text = listItem.product.name,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold
+      )
+      Spacer(modifier = Modifier.height(4.dp))
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        val brand = listItem.product.brand
+        Text(
+          text = if (brand.isNullOrBlank()) "Marca generica" else brand,
+          style = MaterialTheme.typography.bodySmall
+        )
+        Text(
+          text = "${listItem.item.quantity} ${listItem.item.unit}",
+          style = MaterialTheme.typography.bodyMedium
+        )
+      }
+    }
+  }
+}

--- a/app-android/app/src/main/java/com/compareprices/ui/home/HomeViewModel.kt
+++ b/app-android/app/src/main/java/com/compareprices/ui/home/HomeViewModel.kt
@@ -1,0 +1,80 @@
+package com.compareprices.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.compareprices.data.local.ListItemDao
+import com.compareprices.data.local.ListItemEntity
+import com.compareprices.data.local.ProductDao
+import com.compareprices.data.local.ProductEntity
+import com.compareprices.data.local.ShoppingListDao
+import com.compareprices.data.local.ShoppingListEntity
+import com.compareprices.data.local.ShoppingListWithItems
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+  private val productDao: ProductDao,
+  private val shoppingListDao: ShoppingListDao,
+  private val listItemDao: ListItemDao
+) : ViewModel() {
+  private val _uiState = MutableStateFlow(HomeUiState())
+  val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
+
+  init {
+    viewModelScope.launch {
+      seedIfNeeded()
+    }
+    viewModelScope.launch {
+      shoppingListDao.observeLatestList().collect { list ->
+        _uiState.value = HomeUiState(list)
+      }
+    }
+  }
+
+  private suspend fun seedIfNeeded() {
+    if (shoppingListDao.count() > 0) {
+      return
+    }
+
+    val products = listOf(
+      ProductEntity(name = "Leche entera", brand = "La Serenisima", defaultUnit = "litro"),
+      ProductEntity(name = "Pan integral", brand = "Bimbo", defaultUnit = "unidad"),
+      ProductEntity(name = "Arroz largo fino", brand = "Gallo", defaultUnit = "kg")
+    )
+    val productIds = productDao.insertAll(products)
+    val listId = shoppingListDao.upsert(
+      ShoppingListEntity(name = "Compra semanal", createdAt = System.currentTimeMillis())
+    )
+
+    val items = listOf(
+      ListItemEntity(
+        listId = listId,
+        productId = productIds.getOrElse(0) { 0 },
+        quantity = 2.0,
+        unit = "L"
+      ),
+      ListItemEntity(
+        listId = listId,
+        productId = productIds.getOrElse(1) { 0 },
+        quantity = 1.0,
+        unit = "unidad"
+      ),
+      ListItemEntity(
+        listId = listId,
+        productId = productIds.getOrElse(2) { 0 },
+        quantity = 1.0,
+        unit = "kg"
+      )
+    )
+    listItemDao.upsertAll(items)
+  }
+}
+
+data class HomeUiState(
+  val list: ShoppingListWithItems? = null
+)


### PR DESCRIPTION
### Motivation
- Provide a usable home screen showing a seeded shopping list so the app has an initial, observable dataset for development and demo. 
- Add Room relation models and DAO helpers to hydrate lists with product details for the UI and future features (totals, comparisons, history).

### Description
- Add Room relation data models `ListItemWithProduct` and `ShoppingListWithItems` to `data/local/Entities.kt` to represent hydrated lists with product info. 
- Extend DAOs in `data/local/Daos.kt` with `ProductDao.insertAll`, `ShoppingListDao.count`, and a transactional `observeLatestList(): Flow<ShoppingListWithItems?>` to seed and observe the latest list. 
- Implement `HomeViewModel` (`ui/home/HomeViewModel.kt`) that seeds starter products and a shopping list when DB is empty and exposes the latest list state. 
- Add a Compose `HomeScreen` (`ui/home/HomeScreen.kt`) that renders the shopping list and items, and wire it into navigation by replacing the home placeholder in `ui/AppRoot.kt`. 
- Seeded demo data includes three products and one shopping list with three list items for quick local inspection. 

### Testing
- Ran the project CI script `./scripts/run-ci-local.sh` as required by `app-android/AGENTS.md`, which failed with `ANDROID_HOME/ANDROID_SDK_ROOT not set` and therefore prevented a full local build/CI run. 
- No other automated tests were run in this environment, so compilation and runtime behavior on device/emulator remain unverified in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69780f93ae8c832185ca16d30f760626)