### PR TITLE
Add Settings screen UI and wire it into app navigation

### DIFF
--- a/app-android/app/src/main/java/com/compareprices/ui/AppRoot.kt
+++ b/app-android/app/src/main/java/com/compareprices/ui/AppRoot.kt
@@ -1,6 +1,5 @@
 package com.compareprices.ui
 
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Home
@@ -13,13 +12,14 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.compose.ui.Modifier
 import com.compareprices.ui.home.HomeScreen
+import com.compareprices.ui.settings.SettingsScreen
 
 private sealed class Screen(val route: String, val label: String) {
   data object Home : Screen("home", "Lista")
@@ -72,20 +72,5 @@ fun AppRoot() {
       composable(Screen.Compare.route) { com.compareprices.ui.compare.CompareScreen() }
       composable(Screen.Settings.route) { SettingsScreen() }
     }
-  }
-}
-
-@Composable
-private fun SettingsScreen() {
-  PlaceholderScreen(label = "Configuracion")
-}
-
-@Composable
-private fun PlaceholderScreen(label: String) {
-  androidx.compose.foundation.layout.Box(
-    modifier = Modifier.fillMaxSize(),
-    contentAlignment = androidx.compose.ui.Alignment.Center
-  ) {
-    Text(text = label)
   }
 }

--- a/app-android/app/src/main/java/com/compareprices/ui/settings/SettingsScreen.kt
+++ b/app-android/app/src/main/java/com/compareprices/ui/settings/SettingsScreen.kt
@@ -1,0 +1,197 @@
+package com.compareprices.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.NotificationsActive
+import androidx.compose.material.icons.outlined.Payments
+import androidx.compose.material.icons.outlined.Storefront
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingsScreen() {
+  LazyColumn(
+    modifier = Modifier.fillMaxSize(),
+    contentPadding = PaddingValues(16.dp),
+    verticalArrangement = Arrangement.spacedBy(16.dp)
+  ) {
+    item {
+      SettingsHeader()
+    }
+
+    item {
+      PreferencesCard()
+    }
+
+    item {
+      AlertsCard()
+    }
+
+    item {
+      PlanCard()
+    }
+
+    item {
+      AboutCard()
+    }
+  }
+}
+
+@Composable
+private fun SettingsHeader() {
+  Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+    Text(
+      text = "Ajustes",
+      style = MaterialTheme.typography.headlineSmall,
+      fontWeight = FontWeight.Bold
+    )
+    Text(
+      text = "Configura tus tiendas favoritas, alertas y plan de la app.",
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+  }
+}
+
+@Composable
+private fun PreferencesCard() {
+  SettingsCard(title = "Preferencias de compra") {
+    SettingsRow(
+      icon = { Icon(Icons.Outlined.LocationOn, contentDescription = null) },
+      title = "Zona",
+      value = "Centro - CDMX"
+    )
+    SettingsRow(
+      icon = { Icon(Icons.Outlined.Storefront, contentDescription = null) },
+      title = "Tiendas activas",
+      value = "Walmart, Soriana, Chedraui"
+    )
+  }
+}
+
+@Composable
+private fun AlertsCard() {
+  SettingsCard(title = "Alertas y precios") {
+    SettingsRow(
+      icon = { Icon(Icons.Outlined.NotificationsActive, contentDescription = null) },
+      title = "Alertas",
+      value = "Baja de precio semanal"
+    )
+    SettingsRow(
+      icon = { Icon(Icons.Outlined.Payments, contentDescription = null) },
+      title = "Meta de ahorro",
+      value = "Ahorrar $120 esta semana"
+    )
+  }
+}
+
+@Composable
+private fun PlanCard() {
+  SettingsCard(title = "Plan") {
+    SettingsRow(
+      icon = { Icon(Icons.Outlined.Payments, contentDescription = null) },
+      title = "Plan actual",
+      value = "Free con anuncios"
+    )
+    SettingsRow(
+      icon = { Icon(Icons.Outlined.Payments, contentDescription = null) },
+      title = "Upgrade",
+      value = "Pro: sin anuncios + historial extendido"
+    )
+  }
+}
+
+@Composable
+private fun AboutCard() {
+  SettingsCard(title = "Acerca de") {
+    SettingsRow(
+      icon = { Icon(Icons.Outlined.Info, contentDescription = null) },
+      title = "Version",
+      value = "MVP 0.1"
+    )
+    SettingsRow(
+      icon = { Icon(Icons.Outlined.Info, contentDescription = null) },
+      title = "Soporte",
+      value = "hola@comparador.app"
+    )
+  }
+}
+
+@Composable
+private fun SettingsCard(
+  title: String,
+  content: @Composable () -> Unit
+) {
+  Card(
+    modifier = Modifier.fillMaxWidth(),
+    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+  ) {
+    Column(
+      modifier = Modifier.padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+      Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold
+      )
+      content()
+    }
+  }
+}
+
+@Composable
+private fun SettingsRow(
+  icon: @Composable () -> Unit,
+  title: String,
+  value: String
+) {
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp)
+  ) {
+    Surface(
+      tonalElevation = 2.dp,
+      shape = MaterialTheme.shapes.small,
+      color = MaterialTheme.colorScheme.surfaceVariant
+    ) {
+      Row(
+        modifier = Modifier.padding(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+      ) {
+        icon()
+      }
+    }
+    Column(modifier = Modifier.weight(1f)) {
+      Text(text = title, style = MaterialTheme.typography.bodyMedium)
+      Spacer(modifier = Modifier.height(2.dp))
+      Text(
+        text = value,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Replace the placeholder settings destination with a real Settings screen to surface MVP configuration and app info. 
- Provide clear sections for preferences, alerts, plan, and about so the app is immediately more inspectable in the demo flow. 
- Keep navigation simple by wiring the new screen into the existing bottom navigation host.

### Description
- Hooked up the real `SettingsScreen` into the app navigation by updating `AppRoot.kt` to import and route `com.compareprices.ui.settings.SettingsScreen` and remove the placeholder. 
- Added a new `SettingsScreen.kt` under `app/src/main/java/com/compareprices/ui/settings/` implementing composables for `SettingsHeader`, `PreferencesCard`, `AlertsCard`, `PlanCard`, `AboutCard`, `SettingsCard`, and `SettingsRow`. 
- The new screen uses Material3 components and icons to display mock values for `Zona`, `Tiendas activas`, alert settings, plan info, and app metadata to match the MVP demo scope. 

### Testing
- Ran the lint task `./gradlew :app:lintDebug` which could not complete due to a missing Gradle wrapper JAR in the environment (error: `Could not find or load main class org.gradle.wrapper.GradleWrapperMain`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979775450dc832188dda8b1307bc914)