### PR TITLE
Refactor Settings UI to data-driven sections and add unit tests

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -2,6 +2,7 @@
 
 ## Status update (2026-02-01)
 - Agent 2 added: Compare screen sorts stores by total price, highlights the cheapest option, includes unit tests for price parsing/sorting, and now includes Walmart demo pricing data for real-supermarket search context.
+- Agent 2 added: Settings screen now uses structured section data for MVP defaults, with unit tests validating the default settings content.
 
 ## Status update (2026-01-25)
 - Agent 1 outputs drafted: `docs/mvp-scope.md`, `docs/wireframes/ux-flow.md`, `docs/wireframes/notes.md`

--- a/app-android/app/src/main/java/com/compareprices/ui/AppRoot.kt
+++ b/app-android/app/src/main/java/com/compareprices/ui/AppRoot.kt
@@ -1,6 +1,5 @@
 package com.compareprices.ui
 
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Home
@@ -13,13 +12,14 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.compose.ui.Modifier
 import com.compareprices.ui.home.HomeScreen
+import com.compareprices.ui.settings.SettingsScreen
 
 private sealed class Screen(val route: String, val label: String) {
   data object Home : Screen("home", "Lista")
@@ -72,20 +72,5 @@ fun AppRoot() {
       composable(Screen.Compare.route) { com.compareprices.ui.compare.CompareScreen() }
       composable(Screen.Settings.route) { SettingsScreen() }
     }
-  }
-}
-
-@Composable
-private fun SettingsScreen() {
-  PlaceholderScreen(label = "Configuracion")
-}
-
-@Composable
-private fun PlaceholderScreen(label: String) {
-  androidx.compose.foundation.layout.Box(
-    modifier = Modifier.fillMaxSize(),
-    contentAlignment = androidx.compose.ui.Alignment.Center
-  ) {
-    Text(text = label)
   }
 }

--- a/app-android/app/src/main/java/com/compareprices/ui/settings/SettingsContent.kt
+++ b/app-android/app/src/main/java/com/compareprices/ui/settings/SettingsContent.kt
@@ -1,0 +1,84 @@
+package com.compareprices.ui.settings
+
+data class SettingsSection(
+  val title: String,
+  val items: List<SettingsItem>
+)
+
+data class SettingsItem(
+  val title: String,
+  val value: String,
+  val icon: SettingsIcon
+)
+
+enum class SettingsIcon {
+  Location,
+  Storefront,
+  Notifications,
+  Payments,
+  Info
+}
+
+fun defaultSettingsSections(): List<SettingsSection> =
+  listOf(
+    SettingsSection(
+      title = "Preferencias de compra",
+      items = listOf(
+        SettingsItem(
+          title = "Zona",
+          value = "Centro - CDMX",
+          icon = SettingsIcon.Location
+        ),
+        SettingsItem(
+          title = "Tiendas activas",
+          value = "Walmart, Soriana, Chedraui",
+          icon = SettingsIcon.Storefront
+        )
+      )
+    ),
+    SettingsSection(
+      title = "Alertas y precios",
+      items = listOf(
+        SettingsItem(
+          title = "Alertas",
+          value = "Baja de precio semanal",
+          icon = SettingsIcon.Notifications
+        ),
+        SettingsItem(
+          title = "Meta de ahorro",
+          value = "Ahorrar $120 esta semana",
+          icon = SettingsIcon.Payments
+        )
+      )
+    ),
+    SettingsSection(
+      title = "Plan",
+      items = listOf(
+        SettingsItem(
+          title = "Plan actual",
+          value = "Free con anuncios",
+          icon = SettingsIcon.Payments
+        ),
+        SettingsItem(
+          title = "Upgrade",
+          value = "Pro: sin anuncios + historial extendido",
+          icon = SettingsIcon.Payments
+        )
+      )
+    ),
+    SettingsSection(
+      title = "Acerca de",
+      items = listOf(
+        SettingsItem(
+          title = "Version",
+          value = "MVP 0.1",
+          icon = SettingsIcon.Info
+        ),
+        SettingsItem(
+          title = "Soporte",
+          value = "hola@comparador.app",
+          icon = SettingsIcon.Info
+        )
+      )
+    )
+  )

--- a/app-android/app/src/main/java/com/compareprices/ui/settings/SettingsScreen.kt
+++ b/app-android/app/src/main/java/com/compareprices/ui/settings/SettingsScreen.kt
@@ -1,0 +1,149 @@
+package com.compareprices.ui.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material.icons.outlined.NotificationsActive
+import androidx.compose.material.icons.outlined.Payments
+import androidx.compose.material.icons.outlined.Storefront
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SettingsScreen() {
+  val sections = defaultSettingsSections()
+  LazyColumn(
+    modifier = Modifier.fillMaxSize(),
+    contentPadding = PaddingValues(16.dp),
+    verticalArrangement = Arrangement.spacedBy(16.dp)
+  ) {
+    item {
+      SettingsHeader()
+    }
+
+    sections.forEach { section ->
+      item {
+        SettingsSectionCard(section)
+      }
+    }
+  }
+}
+
+@Composable
+private fun SettingsHeader() {
+  Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+    Text(
+      text = "Ajustes",
+      style = MaterialTheme.typography.headlineSmall,
+      fontWeight = FontWeight.Bold
+    )
+    Text(
+      text = "Configura tus tiendas favoritas, alertas y plan de la app.",
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+  }
+}
+
+@Composable
+private fun SettingsSectionCard(section: SettingsSection) {
+  SettingsCard(title = section.title) {
+    section.items.forEach { item ->
+      SettingsRow(
+        icon = { SettingsIconBadge(item.icon) },
+        title = item.title,
+        value = item.value
+      )
+    }
+  }
+}
+
+@Composable
+private fun SettingsCard(
+  title: String,
+  content: @Composable () -> Unit
+) {
+  Card(
+    modifier = Modifier.fillMaxWidth(),
+    colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+  ) {
+    Column(
+      modifier = Modifier.padding(16.dp),
+      verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+      Text(
+        text = title,
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold
+      )
+      content()
+    }
+  }
+}
+
+@Composable
+private fun SettingsRow(
+  icon: @Composable () -> Unit,
+  title: String,
+  value: String
+) {
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+    horizontalArrangement = Arrangement.spacedBy(12.dp)
+  ) {
+    Surface(
+      tonalElevation = 2.dp,
+      shape = MaterialTheme.shapes.small,
+      color = MaterialTheme.colorScheme.surfaceVariant
+    ) {
+      Row(
+        modifier = Modifier.padding(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+      ) {
+        icon()
+      }
+    }
+    Column(modifier = Modifier.weight(1f)) {
+      Text(text = title, style = MaterialTheme.typography.bodyMedium)
+      Spacer(modifier = Modifier.height(2.dp))
+      Text(
+        text = value,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+      )
+    }
+  }
+}
+
+@Composable
+private fun SettingsIconBadge(icon: SettingsIcon) {
+  val vector = when (icon) {
+    SettingsIcon.Location -> Icons.Outlined.LocationOn
+    SettingsIcon.Storefront -> Icons.Outlined.Storefront
+    SettingsIcon.Notifications -> Icons.Outlined.NotificationsActive
+    SettingsIcon.Payments -> Icons.Outlined.Payments
+    SettingsIcon.Info -> Icons.Outlined.Info
+  }
+  Icon(vector, contentDescription = null)
+}

--- a/app-android/app/src/test/java/com/compareprices/ui/settings/SettingsContentTest.kt
+++ b/app-android/app/src/test/java/com/compareprices/ui/settings/SettingsContentTest.kt
@@ -1,0 +1,26 @@
+package com.compareprices.ui.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SettingsContentTest {
+  @Test
+  fun `default sections include expected titles`() {
+    val sections = defaultSettingsSections()
+
+    val titles = sections.map { it.title }
+
+    assertEquals(
+      listOf("Preferencias de compra", "Alertas y precios", "Plan", "Acerca de"),
+      titles
+    )
+  }
+
+  @Test
+  fun `default sections include at least two items each`() {
+    val sections = defaultSettingsSections()
+
+    assertTrue(sections.all { it.items.size >= 2 })
+  }
+}


### PR DESCRIPTION
### Motivation
- Replace the placeholder Settings destination with a reusable, data-driven Settings surface so the UI is driven by plain models and is easier to test and extend. 
- Provide MVP default content for preferences, alerts, plan and about sections so the screen can be rendered consistently from shared data. 
- Wire the real `SettingsScreen` into navigation and record the change in the agents status notes. 

### Description
- Added `app-android/app/src/main/java/com/compareprices/ui/settings/SettingsContent.kt` which defines `SettingsSection`, `SettingsItem`, `SettingsIcon` and `defaultSettingsSections()` providing the default MVP content. 
- Refactored `app-android/app/src/main/java/com/compareprices/ui/settings/SettingsScreen.kt` to render the UI from `defaultSettingsSections()` and added `SettingsSectionCard` and `SettingsIconBadge` helpers to map icons to model values. 
- Updated `app-android/app/src/main/java/com/compareprices/ui/AppRoot.kt` to import and route the real `SettingsScreen` and remove the simple placeholder. 
- Added unit tests at `app-android/app/src/test/java/com/compareprices/ui/settings/SettingsContentTest.kt` to validate default section titles and item counts. 
- Updated `agents.md` to note the Settings content refactor and tests. 

### Testing
- Attempted to run the local CI script with `./scripts/run-ci-local.sh`, which failed due to the environment missing `ANDROID_HOME`/`ANDROID_SDK_ROOT`. 
- Unit tests were added under `app-android/app/src/test/` but were not executed in CI because the Android SDK environment is not available in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979775450dc832188dda8b1307bc914)