### PR TITLE
Add ticket for location-based price coverage

### DIFF
--- a/tickets.md
+++ b/tickets.md
@@ -211,6 +211,22 @@ Integrar una fuente real de precios (API o feed permitido) para reemplazar datos
 
 ---
 
+### TICKET 3.4 — Cambios de precios por ubicación cercana
+**Tipo:** Feature  
+**Prioridad:** P1  
+**Owner:** Agent 3 (Data) + Agent 2 (Android)
+
+**Descripción**
+Agregar soporte para cambios de precios por ubicación, garantizando que cuando se consulten precios exista cobertura en una ubicación cercana.
+
+**Criterios de aceptación**
+- Los precios se asocian a una ubicación (zona/sucursal) con coordenadas o identificador.
+- Al consultar precios, se requiere una ubicación de referencia y se seleccionan precios de la ubicación más cercana disponible.
+- Se define y documenta un radio máximo de cercanía (fallback si no hay precios dentro del radio).
+- Pruebas que validen la selección por cercanía y el fallback cuando no hay cobertura.
+
+---
+
 ## Epic 4 — Matching avanzado (opcional Rust)
 ---
 


### PR DESCRIPTION
### Motivation
- Add a backlog ticket to require that price data be associated with locations and to guarantee that price queries return coverage from a nearby location or a documented fallback.

### Description
- Add `TICKET 3.4` to `tickets.md` which defines the feature, owners (`Agent 3 (Data)` + `Agent 2 (Android)`), and acceptance criteria that prices are tied to a location identifier/coordinates, queries require a reference location and pick the nearest available prices, a maximum proximity radius and fallback behavior are documented, and tests validate proximity selection and fallback.

### Testing
- No automated tests were run because this is a documentation/backlog change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ac8faadc88321a96ed7746c37c5b7)