### PR TITLE
Make demo seeding idempotent (serialize seeding + tests)

### DIFF
--- a/app-android/app/src/main/java/com/compareprices/data/local/DemoSeedData.kt
+++ b/app-android/app/src/main/java/com/compareprices/data/local/DemoSeedData.kt
@@ -1,8 +1,15 @@
 package com.compareprices.data.local
 
 import androidx.room.withTransaction
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 private const val DEMO_LIST_NAME = "Compra semanal"
+private val seedMutex = Mutex()
+
+internal fun interface DemoSeedTransactionRunner {
+  suspend fun runInTransaction(block: suspend () -> Unit)
+}
 
 internal suspend fun seedDemoDataIfNeeded(
   database: AppDatabase,
@@ -10,46 +17,64 @@ internal suspend fun seedDemoDataIfNeeded(
   productDao: ProductDao,
   listItemDao: ListItemDao
 ) {
-  database.withTransaction {
-    val existingList = shoppingListDao.findByName(DEMO_LIST_NAME)
-    if (existingList != null) {
-      return@withTransaction
-    }
+  seedDemoDataIfNeeded(
+    transactionRunner = DemoSeedTransactionRunner { block ->
+      database.withTransaction { block() }
+    },
+    shoppingListDao = shoppingListDao,
+    productDao = productDao,
+    listItemDao = listItemDao
+  )
+}
 
-    val listId = shoppingListDao.insertIgnore(
-      ShoppingListEntity(name = DEMO_LIST_NAME, createdAt = System.currentTimeMillis())
-    )
-    if (listId == -1L) {
-      return@withTransaction
-    }
+internal suspend fun seedDemoDataIfNeeded(
+  transactionRunner: DemoSeedTransactionRunner,
+  shoppingListDao: ShoppingListDao,
+  productDao: ProductDao,
+  listItemDao: ListItemDao
+) {
+  seedMutex.withLock {
+    transactionRunner.runInTransaction {
+      val existingList = shoppingListDao.findByName(DEMO_LIST_NAME)
+      if (existingList != null) {
+        return@runInTransaction
+      }
 
-    val products = listOf(
-      ProductEntity(name = "Leche entera", brand = "La Serenisima", defaultUnit = "litro"),
-      ProductEntity(name = "Pan integral", brand = "Bimbo", defaultUnit = "unidad"),
-      ProductEntity(name = "Arroz largo fino", brand = "Gallo", defaultUnit = "kg")
-    )
-    val productIds = productDao.insertAll(products)
-
-    val items = listOf(
-      ListItemEntity(
-        listId = listId,
-        productId = productIds.getOrElse(0) { 0 },
-        quantity = 2.0,
-        unit = "L"
-      ),
-      ListItemEntity(
-        listId = listId,
-        productId = productIds.getOrElse(1) { 0 },
-        quantity = 1.0,
-        unit = "unidad"
-      ),
-      ListItemEntity(
-        listId = listId,
-        productId = productIds.getOrElse(2) { 0 },
-        quantity = 1.0,
-        unit = "kg"
+      val listId = shoppingListDao.insertIgnore(
+        ShoppingListEntity(name = DEMO_LIST_NAME, createdAt = System.currentTimeMillis())
       )
-    )
-    listItemDao.upsertAll(items)
+      if (listId == -1L) {
+        return@runInTransaction
+      }
+
+      val products = listOf(
+        ProductEntity(name = "Leche entera", brand = "La Serenisima", defaultUnit = "litro"),
+        ProductEntity(name = "Pan integral", brand = "Bimbo", defaultUnit = "unidad"),
+        ProductEntity(name = "Arroz largo fino", brand = "Gallo", defaultUnit = "kg")
+      )
+      val productIds = productDao.insertAll(products)
+
+      val items = listOf(
+        ListItemEntity(
+          listId = listId,
+          productId = productIds.getOrElse(0) { 0 },
+          quantity = 2.0,
+          unit = "L"
+        ),
+        ListItemEntity(
+          listId = listId,
+          productId = productIds.getOrElse(1) { 0 },
+          quantity = 1.0,
+          unit = "unidad"
+        ),
+        ListItemEntity(
+          listId = listId,
+          productId = productIds.getOrElse(2) { 0 },
+          quantity = 1.0,
+          unit = "kg"
+        )
+      )
+      listItemDao.upsertAll(items)
+    }
   }
 }

--- a/app-android/app/src/test/java/com/compareprices/data/local/DemoSeedDataTest.kt
+++ b/app-android/app/src/test/java/com/compareprices/data/local/DemoSeedDataTest.kt
@@ -1,0 +1,99 @@
+package com.compareprices.data.local
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.coroutineScope
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DemoSeedDataTest {
+  @Test
+  fun `seeding is idempotent across concurrent calls`() = runBlocking {
+    val store = FakeSeedStore()
+    val transactionRunner = DemoSeedTransactionRunner { block -> block() }
+
+    coroutineScope {
+      val jobs = List(2) {
+        launch(Dispatchers.Default) {
+          seedDemoDataIfNeeded(
+            transactionRunner = transactionRunner,
+            shoppingListDao = store.shoppingListDao,
+            productDao = store.productDao,
+            listItemDao = store.listItemDao
+          )
+        }
+      }
+      jobs.joinAll()
+    }
+
+    assertEquals(1, store.shoppingLists.size)
+    assertEquals(3, store.products.size)
+    assertEquals(3, store.listItems.size)
+  }
+}
+
+private class FakeSeedStore {
+  private val shoppingListRecords = mutableListOf<ShoppingListEntity>()
+  private val productRecords = mutableListOf<ProductEntity>()
+  private val listItemRecords = mutableListOf<ListItemEntity>()
+
+  val shoppingListDao: ShoppingListDao = object : ShoppingListDao {
+    override suspend fun getAll(): List<ShoppingListEntity> = shoppingListRecords.toList()
+
+    override suspend fun findByName(name: String): ShoppingListEntity? =
+      shoppingListRecords.firstOrNull { it.name == name }
+
+    override suspend fun insertIgnore(item: ShoppingListEntity): Long {
+      delay(50)
+      val nextId = (shoppingListRecords.maxOfOrNull { it.id } ?: 0) + 1
+      shoppingListRecords.add(item.copy(id = nextId))
+      return nextId
+    }
+
+    override suspend fun upsert(item: ShoppingListEntity): Long {
+      shoppingListRecords.add(item)
+      return item.id
+    }
+
+    override suspend fun count(): Int = shoppingListRecords.size
+
+    override fun observeLatestList() = throw NotImplementedError("Not used in test")
+  }
+
+  val productDao: ProductDao = object : ProductDao {
+    override suspend fun getAll(): List<ProductEntity> = productRecords.toList()
+
+    override suspend fun upsertAll(items: List<ProductEntity>) {
+      productRecords.addAll(items)
+    }
+
+    override suspend fun insertAll(items: List<ProductEntity>): List<Long> {
+      val startId = (productRecords.maxOfOrNull { it.id } ?: 0) + 1
+      val ids = items.indices.map { index -> startId + index }
+      productRecords.addAll(items.mapIndexed { index, item -> item.copy(id = ids[index]) })
+      return ids
+    }
+  }
+
+  val listItemDao: ListItemDao = object : ListItemDao {
+    override suspend fun itemsForList(listId: Long): List<ListItemEntity> =
+      listItemRecords.filter { it.listId == listId }
+
+    override suspend fun upsertAll(items: List<ListItemEntity>) {
+      listItemRecords.addAll(items)
+    }
+  }
+
+  val shoppingLists: List<ShoppingListEntity>
+    get() = shoppingListRecords.toList()
+
+  val products: List<ProductEntity>
+    get() = productRecords.toList()
+
+  val listItems: List<ListItemEntity>
+    get() = listItemRecords.toList()
+
+}

--- a/tickets.md
+++ b/tickets.md
@@ -410,3 +410,17 @@ Revisar la estrategia de seeding de datos demo y ampliar los unit tests de concu
 **Criterios de aceptación**
 - Tests que simulen llamadas concurrentes a seeding sin duplicados.
 - Documentación de riesgos conocidos y mitigaciones.
+
+---
+
+### TICKET 8.2 — Endurecer deduplicación de productos demo
+**Tipo:** Task  
+**Prioridad:** P2  
+**Owner:** Agent 2
+
+**Descripción**
+Definir una estrategia de deduplicación para productos demo (por ejemplo, índices únicos por nombre+marca o IDs determinísticos) para evitar duplicados si se agregan nuevos flows de seeding.
+
+**Criterios de aceptación**
+- Propuesta documentada en el código o docs.
+- Se valida que los productos demo no se dupliquen en escenarios de re-seed.


### PR DESCRIPTION
### Motivation
- Prevent duplicate demo shopping lists/items when `seedDemoDataIfNeeded` is called concurrently from multiple ViewModels or coroutines. 
- Make seeding behavior testable and injectable so concurrent scenarios can be validated deterministically. 

### Description
- Serialize demo seeding by adding a `Mutex` and a `DemoSeedTransactionRunner` abstraction and moving the seeding logic into an injectable overload of `seedDemoDataIfNeeded` in `app-android/app/src/main/java/com/compareprices/data/local/DemoSeedData.kt`. 
- Keep the original `seedDemoDataIfNeeded(database, ...)` entrypoint but delegate to the new injectable runner that calls `database.withTransaction`. 
- Add a unit test `DemoSeedDataTest` at `app-android/app/src/test/java/com/compareprices/data/local/DemoSeedDataTest.kt` that uses fake DAOs to simulate concurrent seeding and asserts no duplicates are created. 
- Add a backlog ticket `TICKET 8.2` in `tickets.md` proposing a stronger deduplication strategy for demo products. 

### Testing
- Added `DemoSeedDataTest` unit test that verifies idempotency under concurrent calls using in-memory fakes and coroutine concurrency. 
- Attempted to run CI locally via `./scripts/run-ci-local.sh`, but it failed due to the environment missing `ANDROID_HOME`/`ANDROID_SDK_ROOT`, so full Gradle tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c286008c48321948f20875b7ea583)