### PR TITLE
Align compare totals with list items

### DIFF
--- a/app-android/app/src/test/java/com/compareprices/ui/compare/CompareScreenTest.kt
+++ b/app-android/app/src/test/java/com/compareprices/ui/compare/CompareScreenTest.kt
@@ -1,5 +1,8 @@
 package com.compareprices.ui.compare
 
+import com.compareprices.data.local.ListItemEntity
+import com.compareprices.data.local.ListItemWithProduct
+import com.compareprices.data.local.ProductEntity
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.util.Date
@@ -32,6 +35,26 @@ class CompareScreenTest {
     val filtered = filterStorePrices("Arroz", stores)
 
     assertEquals(4, filtered.size)
+  }
+
+  @Test
+  fun `filters store prices to items from the list`() {
+    val stores = demoStorePrices()
+    val listItems = listOf(
+      ListItemWithProduct(
+        item = ListItemEntity(id = 1, listId = 1, productId = 10, quantity = 1.0, unit = "unidad"),
+        product = ProductEntity(id = 10, name = "Leche entera", brand = "La Serenisima")
+      ),
+      ListItemWithProduct(
+        item = ListItemEntity(id = 2, listId = 1, productId = 11, quantity = 1.0, unit = "unidad"),
+        product = ProductEntity(id = 11, name = "Pan integral", brand = "Bimbo")
+      )
+    )
+
+    val filtered = filterStorePricesByList(stores, listItems)
+
+    assertEquals(4, filtered.size)
+    assertEquals(listOf("Leche entera", "Pan integral"), filtered.first().items.map { it.product })
   }
 
   @Test

--- a/tickets.md
+++ b/tickets.md
@@ -424,3 +424,17 @@ Definir una estrategia de deduplicación para productos demo (por ejemplo, índi
 **Criterios de aceptación**
 - Propuesta documentada en el código o docs.
 - Se valida que los productos demo no se dupliquen en escenarios de re-seed.
+
+---
+
+### TICKET 8.3 — Ajustar totales del comparador según cantidades de la lista
+**Tipo:** Feature  
+**Prioridad:** P2  
+**Owner:** Agent 2
+
+**Descripción**
+Actualizar el comparador para que los totales por tienda respeten las cantidades de cada ítem en la lista (multiplicando el precio unitario por la cantidad y unidad).
+
+**Criterios de aceptación**
+- Los totales por tienda reflejan cantidades reales de la lista.
+- Tests unitarios que validan el cálculo con cantidades distintas a 1.


### PR DESCRIPTION
### Motivation
- The compare screen was using demo store prices for every product, causing totals to include items not present in the active shopping list. 
- The goal is to present store totals and savings that reflect the active list contents so the user sees meaningful comparisons. 
- Add a small test and backlog task to track follow-ups for quantity-aware totals.

### Description
- Filter demo store prices to only include items present in the active shopping list before applying search and sorting by total by adding `filterStorePricesByList` and wiring it into the Compose `CompareScreen` logic (`app-android/app/src/main/java/com/compareprices/ui/compare/CompareScreen.kt`).
- Add a unit test that verifies list-based filtering using `ListItemWithProduct` (`app-android/app/src/test/java/com/compareprices/ui/compare/CompareScreenTest.kt`).
- Add a follow-up backlog ticket `TICKET 8.3` to update totals to account for item quantities in the list (`tickets.md`).

### Testing
- Ran the project CI script `./scripts/run-ci-local.sh` from `app-android/`, which failed early due to environment configuration: `ANDROID_HOME/ANDROID_SDK_ROOT is not set` (no device/SDK available to run Android tasks). 
- The new unit test was added to the test suite but was not executed because of the CI environment error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c328e185883219eb947cde2850271)