### PR TITLE
Add monorepo web/backend structure docs and tasks

### DIFF
--- a/docs/kickoff.md
+++ b/docs/kickoff.md
@@ -40,6 +40,10 @@ Build MVP for a LATAM grocery list price comparator app.
 - Use only metadata + price snapshots.
 - Avoid copying full catalogs from sources.
 
+## Web + backend compartido (nuevo)
+- Propuesta de monorepo con `app-web/`, `api/` y `packages/contracts` para contratos compartidos y generación de tipos.
+- Ver detalle en `docs/monorepo-structure.md`.
+
 ## Next steps (pick up)
 1) Generate Gradle wrapper jar and verify `./gradlew :app:tasks` runs
 2) Implement TICKET 1.2: Room models/DAOs migrations + basic repository layer

--- a/docs/monorepo-structure.md
+++ b/docs/monorepo-structure.md
@@ -1,0 +1,35 @@
+# Propuesta de estructura monorepo (web + backend compartido)
+
+## Objetivo
+Unificar la web y el backend/API en el mismo repositorio para compartir contratos y acelerar el delivery, sin bloquear el trabajo móvil existente.
+
+## Estructura propuesta
+```
+/
+├─ app-android/           # App Android (existente)
+├─ app-web/               # Frontend web (nuevo)
+├─ api/                   # Backend/API (nuevo)
+├─ packages/
+│  └─ contracts/          # OpenAPI/DTOs compartidos + generación de tipos
+├─ docs/
+└─ tasks.md
+```
+
+## Cómo encaja con el backend/API
+- **`packages/contracts` como fuente de verdad**: OpenAPI/JSON Schema con DTOs para listados, productos, precios y listas.
+- **Generación de tipos**:
+  - Web: tipos TypeScript y cliente HTTP (fetch/axios) basados en OpenAPI.
+  - Android: cliente Kotlin opcional o mapeo manual usando el mismo esquema para evitar divergencias.
+- **API alineada con la web**: endpoints mínimos que soportan el flujo de comparación (tiendas, búsqueda, totales de lista, historial de precios).
+
+## Convenciones sugeridas
+- **Versionado de API**: prefijo `/v1`.
+- **Paginado**: `limit` + `cursor` (o `page`) consistente en todos los listados.
+- **Autenticación**:
+  - Público: catálogo de tiendas y búsqueda básica.
+  - Protegido: listas del usuario, historial personalizado y snapshots privados.
+- **CORS**: permitir origen del frontend web (y staging) con allowlist explícita.
+
+## Notas de compatibilidad
+- La app Android puede seguir usando datos locales mientras se integra gradualmente la API.
+- El backend debe exponer datos mínimos para web sin romper los flows actuales.

--- a/tasks.md
+++ b/tasks.md
@@ -2,6 +2,11 @@
 
 ## Seleccionado para esta iteración
 - [x] TICKET 8.6 — Normalizar brand nulo en productos demo.
+- [ ] TICKET 9.1 — Documentar estructura monorepo web + backend compartido.
+- [ ] TICKET 9.2 — Scaffold de frontend web base (app-web/ o web/) con routing, layout y configuración básica.
+- [ ] TICKET 9.3 — Definir contratos compartidos (OpenAPI/DTOs) en packages/contracts con generación de tipos.
+- [ ] TICKET 9.4 — Implementar endpoints mínimos para web (stores, search, list totals, price history) y ajustes de API.
+- [ ] TICKET 9.5 — Configurar CORS, autenticación y paginado (cursor/limit) para consumo web seguro.
 
 ## Completados
 - [x] TICKET 0.1 — Definir alcance del MVP.


### PR DESCRIPTION
### Motivation
- Habilitar una propuesta clara para integrar una web y un backend compartido dentro del repo existente y facilitar trabajo paralelo entre frontend, backend y mobile.
- Definir una convención para contratos compartidos y generación de tipos que evite divergencias entre clientes (web/Android).
- Crear tareas concretas para que agentes/colaboradores puedan implementar el scaffold web, contratos y los endpoints mínimos con consideraciones de CORS, auth y paginado.

### Description
- Se añadió `docs/monorepo-structure.md` que propone la estructura del monorepo (`app-web/`, `api/`, `packages/contracts/`) y describe convenciones de API, paginado y CORS; y explica cómo encaja con el backend/API.
- Se actualizó `docs/kickoff.md` para referenciar la propuesta de `app-web`/`api` y apuntar a `docs/monorepo-structure.md` como referencia.
- Se actualizó `tasks.md` añadiendo TICKETs `9.1`–`9.5` para documentar la estructura monorepo, scaffold del frontend web, definición de contratos compartidos (OpenAPI/DTOs), implementación de endpoints mínimos y configuración de CORS/auth/paginado para consumo web.

### Testing
- No se ejecutaron tests automáticos porque los cambios son de documentación y tareas; no aplica ejecución de tests sobre código fuente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ebdd3c2f483218c14e32961efcaf4)