### PR TITLE
Add web scaffold with routing and layout

### DIFF
--- a/app-web/index.html
+++ b/app-web/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Comparador de precios</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/app-web/package.json
+++ b/app-web/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "comparison-prices-web",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 4173",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 4173",
+    "test": "vitest",
+    "lint": "eslint . --ext ts,tsx --max-warnings=0"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.6",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.3.4",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^9.9.0",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "eslint-plugin-react-refresh": "^0.4.11",
+    "jsdom": "^24.1.1",
+    "typescript": "^5.5.4",
+    "vite": "^5.4.2",
+    "vitest": "^2.0.5"
+  }
+}

--- a/app-web/src/__tests__/router.test.tsx
+++ b/app-web/src/__tests__/router.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { routesForTest } from "../test-utils/routesForTest";
+
+describe("App routing", () => {
+  it("renders the home route by default", () => {
+    const router = createMemoryRouter(routesForTest, { initialEntries: ["/"] });
+    render(<RouterProvider router={router} />);
+
+    expect(screen.getByText("Resumen rápido")).toBeInTheDocument();
+    expect(screen.getByText("Lista activa")).toBeInTheDocument();
+  });
+
+  it("renders the compare route", () => {
+    const router = createMemoryRouter(routesForTest, {
+      initialEntries: ["/comparador"]
+    });
+    render(<RouterProvider router={router} />);
+
+    expect(screen.getByText("Comparador de tiendas")).toBeInTheDocument();
+  });
+});

--- a/app-web/src/layouts/AppLayout.tsx
+++ b/app-web/src/layouts/AppLayout.tsx
@@ -1,0 +1,34 @@
+import { NavLink, Outlet } from "react-router-dom";
+
+const navItems = [
+  { label: "Resumen", to: "/" },
+  { label: "Comparador", to: "/comparador" }
+];
+
+export function AppLayout() {
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <h1>Comparador de precios</h1>
+        <p>Monitorea tu lista y encuentra la mejor tienda en segundos.</p>
+        <nav className="app-nav">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) => (isActive ? "active" : undefined)}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+      </header>
+      <main className="app-main">
+        <Outlet />
+      </main>
+      <footer className="app-footer">
+        Datos demo · Web MVP conectado a contratos compartidos
+      </footer>
+    </div>
+  );
+}

--- a/app-web/src/main.tsx
+++ b/app-web/src/main.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { RouterProvider } from "react-router-dom";
+import { router } from "./router";
+import "./styles.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <RouterProvider router={router} />
+  </React.StrictMode>
+);

--- a/app-web/src/pages/ComparePage.tsx
+++ b/app-web/src/pages/ComparePage.tsx
@@ -1,0 +1,31 @@
+const storeTotals = [
+  { store: "Super A", total: "$18.430", savings: "-8%" },
+  { store: "Mercado Express", total: "$19.980", savings: "-2%" },
+  { store: "Hiper Descuento", total: "$20.400", savings: "+0%" }
+];
+
+export function ComparePage() {
+  return (
+    <section className="page">
+      <div className="card">
+        <h2>Comparador de tiendas</h2>
+        <p>
+          Esta vista presentará el total por tienda usando los contratos
+          compartidos del backend.
+        </p>
+      </div>
+      <div className="grid">
+        {storeTotals.map((store, index) => (
+          <article className="card" key={store.store}>
+            <div className="badge">
+              {index === 0 ? "Mejor opción" : "Alternativa"}
+            </div>
+            <h3>{store.store}</h3>
+            <p>Total estimado: {store.total}</p>
+            <p>Ahorro vs promedio: {store.savings}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app-web/src/pages/HomePage.tsx
+++ b/app-web/src/pages/HomePage.tsx
@@ -1,0 +1,40 @@
+const summaryCards = [
+  {
+    title: "Lista activa",
+    body: "Arroz, leche, huevos, café y 8 ítems más.",
+    badge: "Actualizado hoy"
+  },
+  {
+    title: "Ahorro potencial",
+    body: "Hasta 12% si compras en la tienda recomendada.",
+    badge: "Comparador listo"
+  },
+  {
+    title: "Alertas",
+    body: "3 productos bajaron de precio esta semana.",
+    badge: "Notificaciones on"
+  }
+];
+
+export function HomePage() {
+  return (
+    <section className="page">
+      <div className="card">
+        <h2>Resumen rápido</h2>
+        <p>
+          Este dashboard prepara el terreno para el flujo web: lista activa,
+          comparación por tienda y alertas.
+        </p>
+      </div>
+      <div className="grid">
+        {summaryCards.map((card) => (
+          <article className="card" key={card.title}>
+            <div className="badge">{card.badge}</div>
+            <h3>{card.title}</h3>
+            <p>{card.body}</p>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app-web/src/pages/NotFoundPage.tsx
+++ b/app-web/src/pages/NotFoundPage.tsx
@@ -1,0 +1,10 @@
+export function NotFoundPage() {
+  return (
+    <section className="page">
+      <div className="card">
+        <h2>Página no encontrada</h2>
+        <p>Revisa el menú para volver al comparador.</p>
+      </div>
+    </section>
+  );
+}

--- a/app-web/src/router.tsx
+++ b/app-web/src/router.tsx
@@ -1,0 +1,17 @@
+import { createBrowserRouter } from "react-router-dom";
+import { AppLayout } from "./layouts/AppLayout";
+import { ComparePage } from "./pages/ComparePage";
+import { HomePage } from "./pages/HomePage";
+import { NotFoundPage } from "./pages/NotFoundPage";
+
+export const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <AppLayout />,
+    children: [
+      { index: true, element: <HomePage /> },
+      { path: "comparador", element: <ComparePage /> },
+      { path: "*", element: <NotFoundPage /> }
+    ]
+  }
+]);

--- a/app-web/src/setupTests.ts
+++ b/app-web/src/setupTests.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/app-web/src/styles.css
+++ b/app-web/src/styles.css
@@ -1,0 +1,107 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: #f5f6f9;
+  color: #1b1f29;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  background: #0e1a2b;
+  color: #f8fafc;
+  padding: 1.5rem 2.5rem;
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+}
+
+.app-header p {
+  margin: 0;
+  opacity: 0.8;
+}
+
+.app-nav {
+  display: flex;
+  gap: 1.5rem;
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.app-nav a {
+  padding-bottom: 0.25rem;
+  border-bottom: 2px solid transparent;
+}
+
+.app-nav a.active {
+  border-color: #4ade80;
+  color: #4ade80;
+}
+
+.app-main {
+  flex: 1;
+  padding: 2rem 2.5rem 3rem;
+}
+
+.page {
+  max-width: 920px;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  background: #dcfce7;
+  color: #166534;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.app-footer {
+  padding: 1rem 2.5rem 2rem;
+  color: #52606d;
+  text-align: center;
+  font-size: 0.85rem;
+}

--- a/app-web/src/test-utils/routesForTest.tsx
+++ b/app-web/src/test-utils/routesForTest.tsx
@@ -1,0 +1,17 @@
+import { RouteObject } from "react-router-dom";
+import { AppLayout } from "../layouts/AppLayout";
+import { ComparePage } from "../pages/ComparePage";
+import { HomePage } from "../pages/HomePage";
+import { NotFoundPage } from "../pages/NotFoundPage";
+
+export const routesForTest: RouteObject[] = [
+  {
+    path: "/",
+    element: <AppLayout />,
+    children: [
+      { index: true, element: <HomePage /> },
+      { path: "comparador", element: <ComparePage /> },
+      { path: "*", element: <NotFoundPage /> }
+    ]
+  }
+];

--- a/app-web/tsconfig.app.json
+++ b/app-web/tsconfig.app.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "useDefineForClassFields": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src"]
+}

--- a/app-web/tsconfig.json
+++ b/app-web/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/app-web/tsconfig.node.json
+++ b/app-web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "skipLibCheck": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/app-web/vite.config.ts
+++ b/app-web/vite.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 4173,
+    host: true
+  },
+  test: {
+    environment: "jsdom",
+    setupFiles: "./src/setupTests.ts"
+  }
+});

--- a/docs/app-web-scaffold.md
+++ b/docs/app-web-scaffold.md
@@ -1,0 +1,20 @@
+# Scaffold de frontend web (TICKET 9.2)
+
+## Alcance inicial
+- React + Vite + TypeScript.
+- Routing con `react-router-dom` y layout base compartido.
+- Vistas demo: resumen, comparador y 404.
+- Estilos básicos en `styles.css`.
+
+## Desarrollo local
+```bash
+cd app-web
+npm install
+npm run dev
+```
+
+## Issues potenciales y mitigaciones
+- **Issue:** Los datos demo podrían interpretarse como reales en entornos de pruebas.
+  **Mitigación:** etiquetar explícitamente los bloques demo y reemplazarlos al integrar los contratos del backend.
+- **Issue:** La navegación podría perder estado al cambiar a una estrategia de routing con base path.
+  **Mitigación:** centralizar el base path en el router antes de integrar despliegues en subcarpetas.

--- a/tasks.md
+++ b/tasks.md
@@ -3,7 +3,7 @@
 ## Seleccionado para esta iteración
 - [x] TICKET 8.6 — Normalizar brand nulo en productos demo.
 - [x] TICKET 9.1 — Documentar estructura monorepo web + backend compartido.
-- [ ] TICKET 9.2 — Scaffold de frontend web base (app-web/ o web/) con routing, layout y configuración básica.
+- [x] TICKET 9.2 — Scaffold de frontend web base (app-web/ o web/) con routing, layout y configuración básica.
 - [ ] TICKET 9.3 — Definir contratos compartidos (OpenAPI/DTOs) en packages/contracts con generación de tipos.
 - [ ] TICKET 9.4 — Implementar endpoints mínimos para web (stores, search, list totals, price history) y ajustes de API.
 - [ ] TICKET 9.5 — Configurar CORS, autenticación y paginado (cursor/limit) para consumo web seguro.
@@ -26,3 +26,4 @@
 
 ## Backlog (seguimiento)
 - [ ] TICKET 9.6 — Definir checklist CI para verificar generación de contratos desde `packages/contracts` y detectar divergencias.
+- [ ] TICKET 9.7 — Conectar el scaffold web con contratos reales y datos de API cuando estén disponibles.


### PR DESCRIPTION
### Motivation
- Provide a minimal web frontend scaffold to align the monorepo with the planned web + backend flow and enable faster web MVP development.
- Offer a simple, demonstrable UI (routing + layout + demo pages) that can be wired to shared contracts and the API later.
- Record the work and next steps in project tasks and docs to keep backlog and onboarding consistent.

### Description
- Add a Vite + React + TypeScript scaffold under `app-web/` including `package.json`, `vite.config.ts`, and TypeScript configs for the app and node build references.
- Implement routing and layout with `react-router-dom` via `src/router.tsx` and `src/layouts/AppLayout.tsx`, plus demo pages `HomePage`, `ComparePage`, and `NotFoundPage`.
- Add basic styling in `src/styles.css`, a small test utility `src/test-utils/routesForTest.tsx`, and a route-level unit test `src/__tests__/router.test.tsx` using Testing Library.
- Document the scaffold in `docs/app-web-scaffold.md` and mark TICKET 9.2 completed while adding follow-up TICKET 9.7 to `tasks.md` for connecting the scaffold to real contracts/data.

### Testing
- Attempted `npm install` in `app-web/`, which failed with a `403 Forbidden` from the npm registry, preventing dependency installation and further test execution.
- Unit tests were added (`src/__tests__/router.test.tsx`) but were not executed because dependencies could not be installed, so `npm run test` / `vitest` was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ec44c571c8321b9273cc07d9aedad)